### PR TITLE
Fix bug

### DIFF
--- a/lib/fluent/plugin/filter_pan_anonymizer.rb
+++ b/lib/fluent/plugin/filter_pan_anonymizer.rb
@@ -20,8 +20,13 @@ module Fluent::Plugin
     def configure(conf)
       super
 
+      formats = conf.each_element.map do |i|
+        next if i["formats"].nil?
+        i["formats"].scan(/\/[^\/]*\//).map do |j| j.delete("/") end.map do |j| Regexp.new(j) end
+      end.flatten
+
       @pan_masker = @pan_configs.map do |i|
-        i[:formats].map do |format|
+        formats.map do |format|
           Fluent::PAN::Masker.new(format, i[:checksum_algorithm], i[:mask], i[:force])
         end
       end.flatten

--- a/test/plugin/test_filter_pan_anonymizer.rb
+++ b/test/plugin/test_filter_pan_anonymizer.rb
@@ -120,6 +120,26 @@ class PANAnonymizerFilterTest < Test::Unit::TestCase
 		    create_driver(conf)
 			end
 		end
+    test 'regexp has ,' do
+      conf = %[
+			  <pan>
+          formats /[0-9]{6}[0-9]{3,9}[0-9]{4}/
+			  </pan>
+      ]
+			assert_nothing_raised(Fluent::ConfigError) do
+		    create_driver(conf)
+			end
+		end
+    test 'regexp has "," and multi formats fields' do
+      conf = %[
+			  <pan>
+          formats /[0-9]{6}[0-9]{3,9}[0-9]{4}/, /[0-9]{15}\d*/
+			  </pan>
+      ]
+			assert_nothing_raised(Fluent::ConfigError) do
+		    create_driver(conf)
+			end
+		end
 	end
 
   sub_test_case 'normal case' do
@@ -160,6 +180,48 @@ class PANAnonymizerFilterTest < Test::Unit::TestCase
       expected = [
         {
           "key": "999xxxx999"
+        }
+      ]
+      filtered = filter(conf, messages)
+      assert_equal(expected, filtered)
+    end
+    test "formats has ','" do
+      conf = %[
+        <pan>
+          formats /([0-9]{6})[0-9]{3,9}([0-9]{4})/
+          checksum_algorithm luhn
+          mask xxxx
+        </pan>
+      ]
+      messages = [
+        {
+          "key": "4019249331712145"
+        }
+      ]
+      expected = [
+        {
+          "key": "xxxx"
+        }
+      ]
+      filtered = filter(conf, messages)
+      assert_equal(expected, filtered)
+    end
+    test "formats has ',' and mult formats fields" do
+      conf = %[
+        <pan>
+          formats /([0-9]{6})[0-9]{3,9}([0-9]{4})/ , /[0-9]{15}/
+          checksum_algorithm luhn
+          mask xxxx
+        </pan>
+      ]
+      messages = [
+        {
+          "key": "4019249331712145"
+        }
+      ]
+      expected = [
+        {
+          "key": "xxxx"
         }
       ]
       filtered = filter(conf, messages)


### PR DESCRIPTION
Not works if formats include `,` in `/.../` literal. The related issue https://github.com/kanmu/fluent-plugin-pan-anonymizer/issues/3